### PR TITLE
Updater: Ensure update compatibility by checking timestamps

### DIFF
--- a/app/src/main/java/net/pixelos/ota/misc/Utils.java
+++ b/app/src/main/java/net/pixelos/ota/misc/Utils.java
@@ -106,6 +106,12 @@ public class Utils {
         update.setForumUrl(object.isNull("forum_url") ? "" : object.getString("forum_url"));
         update.setWebsiteUrl(object.isNull("website_url") ? "" : object.getString("website_url"));
         update.setNewsUrl(object.isNull("news_url") ? "" : object.getString("news_url"));
+        try {
+            update.setMinTimestamp (object.getLong("ota_datetime"));
+        } catch (JSONException e) {
+            update.setMinTimestamp (0);
+            Log.d(TAG, "Could not parse ota_datetime", e);
+        }
         return update;
     }
 
@@ -118,6 +124,14 @@ public class Utils {
             Log.d(TAG, update.getName() + " with timestamp " + update.getTimestamp() + " is older than/equal to the current build " + SystemProperties.getLong(Constants.PROP_BUILD_DATE, 0));
             return false;
         }
+        if (update.getMinTimestamp() != 0 ) { 
+            if ( update.getMinTimestamp() > SystemProperties.getLong(Constants.PROP_BUILD_DATE, 0)) {
+                Log.d(TAG, "The minimum timestamp " + update.getMinTimestamp() + " is newer than the current build " + SystemProperties.getLong(Constants.PROP_BUILD_DATE, 0));
+                Log.e(TAG, "CLEAN FLASH MAY BE REQUIRED");
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/app/src/main/java/net/pixelos/ota/model/UpdateBase.java
+++ b/app/src/main/java/net/pixelos/ota/model/UpdateBase.java
@@ -32,6 +32,7 @@ public class UpdateBase implements UpdateBaseInfo {
     private String mNewsUrl;
     private ArrayList<MaintainerInfo> mMaintainers;
     private String mHash;
+    private long mMinTimestamp;
 
     UpdateBase() {
     }
@@ -152,4 +153,14 @@ public class UpdateBase implements UpdateBaseInfo {
     public void setHash(String hash) {
         mHash = hash;
     }
+
+    @Override
+    public long getMinTimestamp () {
+        return mMinTimestamp;
+    }
+
+    public void setMinTimestamp (long Timestamp) {
+        mMinTimestamp = Timestamp;
+    }
+
 }

--- a/app/src/main/java/net/pixelos/ota/model/UpdateBaseInfo.java
+++ b/app/src/main/java/net/pixelos/ota/model/UpdateBaseInfo.java
@@ -42,4 +42,6 @@ public interface UpdateBaseInfo {
     ArrayList<MaintainerInfo> getMaintainers();
 
     String getHash();
+
+    long getMinTimestamp ();
 }


### PR DESCRIPTION
Reject updates if the current build timestamp is less than the minimum required timestamp of the upcoming update. Sometimes, the latest update cannot be applied from a very old version. Use the minimum timestamp to verify if the update is suitable for automatic installation on the device.

Change-Id: I709e456c1061bdc98d49db3a345308c3fe0e0ad3